### PR TITLE
Vanilla GH actions from the marketplace to export usage metrics daily at 2am

### DIFF
--- a/.github/workflows/copilot-usage-metrics-export.yml
+++ b/.github/workflows/copilot-usage-metrics-export.yml
@@ -1,0 +1,25 @@
+name: Copilot Usage Metrics Export
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  export-metrics:
+    runs-on: ubuntu-latest
+    steps:
+      - name: GitHub Copilot Usage Metrics API Export
+        uses: bthomas2622/copilot-metrics-export-action@v1.2
+        with:
+          access-token: ${{ secrets.VUE_APP_GITHUB_TOKEN }}
+          enterprise-summary: true
+          enterprise-name: ${{ secrets.VUE_APP_GITHUB_ENT }}
+          # the following is for GitHub Copilot with GHEC
+          org-summary: true
+          org-name: callmegreg-demo-org
+          team-summary: true
+          team-name: pleasework
+          # the following is for GitHub Copilot for Non-GHEC
+          # enterprise-team-summary: ""
+          # enterprise-team-name: ""


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to export Copilot usage metrics. The workflow is scheduled to run daily and can also be triggered manually.

The actions workflow is using bthomas2622/copilot-metrics-export-action@v1.2 without any modification.